### PR TITLE
Revert "Update dependency System.Threading.RateLimiting to v10"

### DIFF
--- a/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
+++ b/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="10.0.1" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts jellyfin/jellyfin-plugin-discogs#11

We should likely upgrade to 9.x