### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
+++ b/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="12.*-*" />
     <PackageReference Include="System.Threading.RateLimiting" Version="10.0.0" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
+++ b/Jellyfin.Plugin.Discogs/Jellyfin.Plugin.Discogs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Discogs</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Discogs"
 guid: "4ce89c27-d3a1-4e4b-8f5f-4bd9191c857e"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-discogs.png"
 version: 2
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 overview: "Get music metadata from Discogs"
 description: >

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ guid: "4ce89c27-d3a1-4e4b-8f5f-4bd9191c857e"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-discogs.png"
 version: 2
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 overview: "Get music metadata from Discogs"
 description: >
   Get music metadata from Discogs

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Discogs"
 guid: "4ce89c27-d3a1-4e4b-8f5f-4bd9191c857e"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-discogs.png"
 version: 2
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 overview: "Get music metadata from Discogs"
 description: >


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.